### PR TITLE
feat: add support for single quoted grid-template-areas declarations

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -48,7 +48,7 @@ export function activate(context: vscode.ExtensionContext) {
 		/**
 		 * Preferred quote to apply while formatting (e.g. single or double quote).
 		 *
-		 * Note: This determined by the first quote found in the `grid-template-areas` declaration.
+		 * Note: This is determined by the first quote found in the `grid-template-areas` declaration.
 		 */
 		let q
 		let gridAreaRows: string[] = []

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -34,8 +34,8 @@ export function activate(context: vscode.ExtensionContext) {
 		// P5 - Any number of spaces or newlines until the ending semi-colon (lazy)
 		// P6 - Ending declaration semi-colon
 		// P7 - Any number of spaces to the end of the selection
-		//                             P1         P2           P3    P4    P5  P6P7
-		const validGridAreasRegex = /^[ ]*grid-template-areas:\s*?"(.|\n)*"\s*?;[ ]*$/i
+		//                             P1         P2           P3            P4             P5 P6P7
+		const validGridAreasRegex = /^[ ]*grid-template-areas:\s*?['|"](.|\r|\n|\r\n)*['|"]\s*?;[ ]*$/i
 
 		if (!validGridAreasRegex.test(text)) {
 			return vscode.window.showErrorMessage(
@@ -43,13 +43,20 @@ export function activate(context: vscode.ExtensionContext) {
 			)
 		}
 
-		const gridAreaRowsRegex = /"(.*?)"/gi
+		const gridAreaRowsRegex = /(['|"])(.*?)['|"]/gi
 
+		/**
+		 * Preferred quote to apply while formatting (e.g. single or double quote).
+		 *
+		 * Note: This determined by the first quote found in the `grid-template-areas` declaration.
+		 */
+		let q
 		let gridAreaRows: string[] = []
 
 		let match
 		while (match = gridAreaRowsRegex.exec(text)) {
-			gridAreaRows.push(match[1])
+			if (!q) { q = match[1] }
+			gridAreaRows.push(match[2])
 		}
 
 		const normalizedGridAreas = gridAreaRows.map(row => row.trim().split(/\s+/))
@@ -89,13 +96,13 @@ export function activate(context: vscode.ExtensionContext) {
 				formattedGridAreaRows[y] += (
 					// Add an indent and start quote to the first token
 					// otherwise add a space to separate each column
-					(x === 0 ? indentSpaces + '\t"' : ' ') +
+					(x === 0 ? indentSpaces + `\t${q}` : ' ') +
 
 					// Add end padding based on the longest token in the current column
 					token.padEnd(longestTokens[x], ' ') +
 
 					// Add ending quote to the last token
-					(x === longestRowLength - 1 ? '"' : '')
+					(x === longestRowLength - 1 ? q : '')
 				)
 			}
 		}

--- a/test/test.css
+++ b/test/test.css
@@ -44,6 +44,18 @@
 
   grid-template-areas: "one" "two two" "three three three";
 
+  /* Single quotes */
+  grid-template-areas:
+  'three three three'
+  'two two'
+  'one';
+
+  /* Mixing single and double quotes (Should reformat using the first matched quote) */
+  grid-template-areas:
+  'three three three'
+  "two two"
+  'one';
+
   grid-template-areas:
     "one two three"
     /* what if there is a comment */
@@ -51,4 +63,5 @@
 	  /* what if there is a comment */
 	  // what about a non valid css comment
     "three one two";
+
 }

--- a/test/test.css
+++ b/test/test.css
@@ -63,5 +63,4 @@
 	  /* what if there is a comment */
 	  // what about a non valid css comment
     "three one two";
-
 }


### PR DESCRIPTION
- Add `test.css` examples for `single-quoted` and mixed `single and double quoted` grid-format-areas declarations
- Update the implementation to format `single or double-quoted` grid-template-areas declarations

Additionally updated the validation regex to include the windows `CRLF` character.
Closes #3

![2021-04-30 08 17 10](https://user-images.githubusercontent.com/32409546/116718443-d04ba280-a98e-11eb-9b69-6eeee612e6e3.gif)